### PR TITLE
Network and Internet: subsections, add projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ an issue to add a new framework, library or software to the list.
 [24]: http://minispec.org/index.html
 [25]: http://clqr.boundp.org/index.html
 [26]: http://www.paulgraham.com/onlisp.html
-[27]: http://arxiv.org/abs/1209.5626
+[27]: https://arxiv.org/abs/1209.5626
 [28]: http://quickdocs.org/
 [29]: https://github.com/slime/slime
 [30]: https://github.com/fukamachi/datafly

--- a/README.md
+++ b/README.md
@@ -18,45 +18,57 @@ is provided in the LICENSE file. This repository is also mirrored on
 alternative to Github.  Preference is given to [free software][13] and
 sellers who aren't evil for physical resources.
 
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
-- [Awesome Common Lisp](#awesome-common-lisp)
+
 - [Build Systems](#build-systems)
 - [Crypto](#crypto)
 - [Database](#database)
 - [Foreign Function Interface](#foreign-function-interface)
-  - [C](#c)
-  - [Java](#java)
-  - [Miscellaneous](#miscellaneous)
-  - [Python](#python)
+    - [C](#c)
+    - [Java](#java)
+    - [Miscellaneous](#miscellaneous)
+    - [Python](#python)
 - [Game Development](#game-development)
 - [Graphics](#graphics)
 - [GUI](#gui)
 - [Implementations](#implementations)
 - [JSON](#json)
 - [Learning and Tutorials](#learning-and-tutorials)
-  - [Online](#online)
-  - [Beginner](#beginner)
-  - [Intermediate](#intermediate)
-  - [Advanced](#advanced)
-  - [Reference](#reference)
-  - [Offline](#offline)
-  - [Beginner](#beginner-1)
-  - [Intermediate](#intermediate-1)
-  - [Advanced](#advanced-1)
+    - [Online](#online)
+    - [Beginner](#beginner)
+    - [Intermediate](#intermediate)
+    - [Advanced](#advanced)
+    - [Reference](#reference)
+    - [Offline](#offline)
+    - [Beginner](#beginner)
+    - [Intermediate](#intermediate)
+    - [Advanced](#advanced)
 - [Library Manager](#library-manager)
 - [Natural Language Processing](#natural-language-processing)
 - [Network and Internet](#network-and-internet)
+    - [HTTP clients](#http-clients)
+    - [HTTP Servers](#http-servers)
+    - [Web frameworks](#web-frameworks)
+    - [Parsing html](#parsing-html)
+    - [Querying HTML/DOM](#querying-htmldom)
+    - [HTML generators and templates](#html-generators-and-templates)
+    - [URI handling](#uri-handling)
+    - [Javascript](#javascript)
+    - [Others](#others)
 - [Numerical and Scientific](#numerical-and-scientific)
 - [Parallelism and Concurrency](#parallelism-and-concurrency)
 - [Regex](#regex)
 - [Text Editor Resources](#text-editor-resources)
-  - [Emacs](#emacs)
-  - [Vim](#vim)
+    - [Emacs](#emacs)
+    - [Vim](#vim)
 - [Tools](#tools)
 - [Unit Testing](#unit-testing)
 - [Utilities](#utilities)
 - [XML](#xml)
 - [Contributing](#contributing)
+
+<!-- markdown-toc end -->
 
 
 Build Systems
@@ -240,39 +252,77 @@ Natural Language Processing
 Network and Internet
 ====================
 
+See [Cliki](http://www.cliki.net/Web) for more.
+
+HTTP clients
+------------
+* [Dexador][199] - An HTTP client, that aims at [replacing Drakma](http://quickdocs.org/dexador/). [MIT][200].
+
+HTTP Servers
+------------
+* [Clack][90] - A web application environment inspired by Rack and WSGI. [LLGPL][8]. Replaces Hunchentoot.
 * [aserve][110] - AllegroServe; a web server. [LLGPL][8].
-* [avatar-api][105] - Get avatars from Google+, Gravatar and others. [Expat][14].
+* [clack-errors][94] - Error page middleware for Clack. [LLGPL][8].
+* [hermetic][95] - Security for Clack-based web applications. [Expat][14].
+* [wookie][109] - Asynchronous HTTP server. [Expat][14].
+* [woo](https://github.com/fukamachi/woo) - A fast non-blocking HTTP server on top of libev. [MIT][200].
+
+Web frameworks
+--------------
 * [Caveman][92] - A powerful web framework. [LLGPL][8].
+  Example projects: [Quickdocs](https://github.com/quickdocs)
+* [hh-web][183] - Framework for building modern web apps. [Expat][14].
+* [ningle][93] - A super-micro web framework. [LLGPL][8].
+* [radiance][91] - An extensible framework library and multi-application CMS. [Artistic License 2.0][51].
+* [Lucerne](https://github.com/eudoxia0/lucerne) - A minimal web framework built on Clack, inspired by Flask. [MIT][200].
+
+There are more projects, more or less discontinued but interesting. See the other ressources.
+
+Parsing html
+------------
+* [http-parse][73] - An HTTP parser in Common Lisp. [Expat][14].
+* [Plump][71] - A lenient HTTP/XML parser, tolerand on malformed markup. [Artistic License 2.0][51]. Best used with [lquery][72] and [clss][202].
+
+Querying HTML/DOM
+-----------------
+* [lquery][72] - A jQuery-like HTML/DOM manipulation library. [Artistic License 2.0][51].
+
+See also XML below.
+
+
+HTML generators and templates
+-----------------------------
+* [cl-who][184] - An HTML generator. [FreeBSD][39].
+* [spinneret][191] - Common Lisp HTML5 generator. [Expat][14].
+* [cl-markup][101] - Modern markup generation library. [LLGPL][8].
+* [Djula][100] - A port of Django's template engine to Common Lisp. [Expat][14].
+* [eco][98] - Fast, flexible, designer-friendly template engine. [Expat][14].
+
+URI handling
+------------
+* [puri-unicode][75] - Pure URI library with Unicode support. [LLGPL][8].
+
+Javascript
+----------
+* [Parenscript][102] - A translator from Common Lisp to Javascript. [3-clause BSD][15].
+* [parse-js][104] - A package for parsing ECMAScript 3. [zlib][33].
+* [JSCL](https://github.com/jscl-project/jscl) - A CL-to-JS compiler designed to be self-hosting from day one. Lacks CLOS, format and loop.
+
+Others
+------
+
+* [avatar-api][105] - Get avatars from Google+, Gravatar and others. [Expat][14].
 * [chirp][106] - A Twitter client library. [Artistic License 2.0][51].
 * [cl-closure-template][99] - Implementation of Google's Closure templates. [LLGPL][8].
 * [cl-irc][83] - An IRC client library. [Expat][14].
-* [cl-markup][101] - Modern markup generation library. [LLGPL][8].
 * [cl-openid][96] - An implementation of OpenID. [LLGPL][8].
-* [cl-who][184] - An HTML generator. [FreeBSD][39].
 * [cl-ses][193] - Library for AWS SES. [Expat][14].
-* [spinneret][191] - Common Lisp HTML5 generator. [Expat][14].
-* [Clack][90] - A web application environment inspired by Rack and WSGI. [LLGPL][8].
-* [clack-errors][94] - Error page middleware for Clack. [LLGPL][8].
 * [colleen][82] - IRC bot with a modular framework. [Artistic License 2.0][51].
 * [css-lite][185] - A CSS grammar. [Expat][14].
-* [Djula][100] - A port of Django's template engine to Common Lisp. [Expat][14].
-* [Drakma][78] - An HTTP client. [FreeBSD][39].
-* [Dexador][199] - An HTTP client, that aims at replacing Drakma. [MIT][200].
-* [eco][98] - Fast, flexible, designer-friendly template engine. [Expat][14].
-* [hermetic][95] - Security for Clack-based web applications. [Expat][14].
-* [hh-web][183] - Framework for building modern web apps. [Expat][14].
-* [http-parse][73] - An HTTP parser in Common Lisp. [Expat][14].
 * [humbler][107] - A Tumblr API interface. [Artistic License 2.0][51].
-* [hunchentoot][108] - A web server. [FreeBSD][39].
-* [lquery][72] - A jQuery-like HTML/DOM manipulation library. [Artistic License 2.0][51].
-* [ningle][93] - A super-micro web framework. [LLGPL][8].
 * [Postmaster][80] - A simple, easy-to-use SMTP/IMAP library. [Expat][14].
-* [radiance][91] - An extensible framework library and multi-application CMS. [Artistic License 2.0][51].
-* [saluto][97] - OAuth 2.0 module for the RESTAS web framework. Not available on Quicklisp. [3-clause BSD][15].
-* [sytes][182] - A library for making simple websites quickly. Not available on Quicklisp. No license specified.
 * [usocket][79] - A portable TCP and UDP socket interface. [Expat][14].
-* [weblocks][159] - An advanced web framework. [LLGPL][8]
-* [wookie][109] - Asynchronous HTTP server. [Expat][14].
+
 
 Numerical and Scientific
 ========================


### PR DESCRIPTION
Hi again !
Here I add Internet sub-sections and add and remove projects: (based on my little experience and most of all http://eudoxia.me/article/common-lisp-sotu-2015#system)

add JSCL, Lucerne framework, Woo

move Plump into it

Clack replaces Hunchentoot

explain that Dexador replaces Drakma