### PR TITLE
add jupyter kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 
 # Rebuild and push the awesome-cl website
 gh-pages:
-	git clone git@github.com:CodyReichert/awesome-cl
-	cd awesome-cl/
 	git checkout gh-pages
 	git pull --rebase origin gh-pages
 	git show master:README.md > index.md

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 # Rebuild and push the awesome-cl website
 gh-pages:
-        git clone git@github.com:CodyReichert/awesome-cl
-        cd awesome-cl/
+	git clone git@github.com:CodyReichert/awesome-cl
+	cd awesome-cl/
 	git checkout gh-pages
 	git pull --rebase origin gh-pages
 	git show master:README.md > index.md

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ gh-pages:
 	git checkout gh-pages
 	git pull --rebase origin gh-pages
 	git show master:README.md > index.md
+	git add index.md
 	git commit -m "Rebuild index.md"
 	git push -u origin gh-pages
 	git checkout master

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 # Rebuild and push the awesome-cl website
 gh-pages:
+        git clone git@github.com:CodyReichert/awesome-cl
+        cd awesome-cl/
 	git checkout gh-pages
 	git pull --rebase origin gh-pages
 	git show master:README.md > index.md

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ These are applications or bits of code that make development in Common Lisp easi
 * [quicksearch](https://github.com/tkych/quicksearch) - Look up online libraries from the REPL. [Expat][14].
 * [SWIG](http://www.swig.org/) - A tool for generating FFI code from C/C++ header files. [GNU GPL3][2].
 * [cl-project](https://github.com/fukamachi/cl-project) - General modern project skeletons. [LLGPL][8].
+* [cl-jupyter](https://github.com/fredokun/cl-jupyter) - A Common Lisp kernel for Jupyter notebooks [custom licence](https://github.com/fredokun/cl-jupyter/blob/master/LICENSE).
 
 
 Unit Testing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="http://i.imgur.com/jLVXhpc.png">
 </div>
 
-# Awesome Common Lisp [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Assertible](https://assertible.com/apis/19f22308-4694-40f3-973d-69a5584e9a95/status?api_token=8b55a286830323effb)](https://github.com/assertible/deployments)
+# Awesome Common Lisp [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Assertible status](https://assertible.com/apis/102e334d-f9a8-4565-9353-7572de775cae/status?api_token=8b55a286830323effb)](https://assertible.com/docs/guide/deployments)
 
 A curated list of _awesome_ Common Lisp stuff.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ sellers who aren't evil for physical resources.
     - [URI handling](#uri-handling)
     - [Javascript](#javascript)
     - [Websockets](#websockets)
-    - [Third-party APIs](#third-party-apis)
     - [Static site generators](#static-site-generators)
+    - [Third-party APIs](#third-party-apis)
     - [Others](#others)
 - [Numerical and Scientific](#numerical-and-scientific)
 - [Parallelism and Concurrency](#parallelism-and-concurrency)
@@ -68,6 +68,7 @@ sellers who aren't evil for physical resources.
 - [Text Editor Resources](#text-editor-resources)
     - [Emacs](#emacs)
     - [Vim](#vim)
+    - [Notebooks](#notebooks)
 - [Tools](#tools)
 - [Unit Testing](#unit-testing)
 - [Utilities](#utilities)
@@ -453,6 +454,12 @@ This contains plugins and other goodies for various text editors.
 * [SLIMV](https://github.com/kovisoft/slimv) - Superior Lisp Interaction Mode for Vim; a full-blown environment for Common Lisp inside of Vim. No license specified.
 * [Vlime](https://github.com/l04m33/vlime) - VLIME: Vim plus Lisp Is Mostly Evil. A Common Lisp dev environment for Vim (and Neovim). [MIT][200].
 
+## Notebooks
+
+* [cl-jupyter](https://github.com/fredokun/cl-jupyter) - A Common Lisp kernel for Jupyter notebooks [custom licence](https://github.com/fredokun/cl-jupyter/blob/master/LICENSE).
+* [Darkmatter](https://github.com/tamamu/darkmatter) - A
+  notebook-style Common Lisp environment. [MIT][200].
+
 Tools
 =====
 
@@ -463,7 +470,6 @@ These are applications or bits of code that make development in Common Lisp easi
 * [quicksearch](https://github.com/tkych/quicksearch) - Look up online libraries from the REPL. [Expat][14].
 * [SWIG](http://www.swig.org/) - A tool for generating FFI code from C/C++ header files. [GNU GPL3][2].
 * [cl-project](https://github.com/fukamachi/cl-project) - General modern project skeletons. [LLGPL][8].
-* [cl-jupyter](https://github.com/fredokun/cl-jupyter) - A Common Lisp kernel for Jupyter notebooks [custom licence](https://github.com/fredokun/cl-jupyter/blob/master/LICENSE).
 
 
 Unit Testing


### PR DESCRIPTION
it wasn't installable "as is" (a couple of twicks referenced in open
issues)
but it works well.

there's also cl-notebook https://github.com/inaimathi/cl-notebook which
seems buggy as a pre-beta can be.

