### PR TITLE
bknr.datastore, RAM-base DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Database
 * [postmodern](http://marijnhaverbeke.nl/postmodern/) - A library for interacting with PostgreSQL. [zlib][33].
 * [pgloader](https://github.com/dimitri/pgloader) - a data loading tool for PostgreSQL. [PostgreSQL Licence][205].
 * [sxql](https://github.com/fukamachi/sxql) - A DSL for generating SQL. [3-clause BSD][15].
-* [bknr.datastore](http://bknr.net/html/documentation.html) - a CLOS-based lisp-only database in RAM with transaction logging persistence. [licence](http://bknr.net/html/license.html). (see also chap. 21 of "Common Lisp Recipes")
+* [bknr.datastore](https://github.com/hanshuebner/bknr-datastore) - a CLOS-based lisp-only database in RAM with transaction logging persistence. [licence](http://bknr.net/html/license.html). (see also chap. 21 of "Common Lisp Recipes")
 
 
 Foreign Function Interface

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Database
 * [postmodern](http://marijnhaverbeke.nl/postmodern/) - A library for interacting with PostgreSQL. [zlib][33].
 * [pgloader](https://github.com/dimitri/pgloader) - a data loading tool for PostgreSQL. [PostgreSQL Licence][205].
 * [sxql](https://github.com/fukamachi/sxql) - A DSL for generating SQL. [3-clause BSD][15].
+* [bknr.datastore](http://bknr.net/html/documentation.html) - a CLOS-based lisp-only database in RAM with transaction logging persistence. [licence](http://bknr.net/html/license.html). (see also chap. 21 of "Common Lisp Recipes")
 
 
 Foreign Function Interface


### PR DESCRIPTION
discovered in E. Weitz's Recipes.

This looks a bit dated, but pretty interesting, and the reference from the (modern) book is a solid one.