### PR TITLE
link to wuwei fork with ASDF3 and other patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Javascript
 * [parse-js](http://marijnhaverbeke.nl/parse-js/) - A package for parsing ECMAScript 3. [zlib][33].
 * [JSCL](https://github.com/jscl-project/jscl) - A CL-to-JS compiler designed to be self-hosting from day one. Lacks CLOS, format and loop.
 * [CL-JavaScript](http://marijnhaverbeke.nl/cl-javascript/) - A translator from Javascript to Common Lisp. Not available on Quicklisp. [Expat][14].
-* [Wuwei](https://github.com/mtravers/wuwei/) - A toolkit to build Ajax-based web pages. [MIT][200].
+* [Wuwei](https://github.com/mtravers/wuwei/) - A toolkit to build Ajax-based web pages. [MIT][200]. See also [this fork](https://github.com/fare-patches/wuwei) for [these improvements](https://github.com/mtravers/wuwei/pull/16).
 * [Panic](https://github.com/michaeljforster/panic), a Parenscript library for React. Not in Quicklisp. [MIT][200]. Its [TodoMVC example](https://github.com/40ants/todomvc/blob/common-lisp-example/examples/common-lisp-react/src/app.lisp).
 
 Websockets


### PR DESCRIPTION
https://github.com/mtravers/wuwei/pull/16#issuecomment-311855130
https://github.com/fare-patches/wuwei

changes:
«
1- Follow the ASDF best_practices document for wuwei.asd, notably
use wuwei/examples instead of wuwei-examples as secondary system name.

2- Stop using the deprecated run-shell-command, use shell-program.
»

you judge if it's worth merging ! Cheers.