### PR TITLE
Add a reference to Vlime, a Common Lisp dev environment for Vim (and Neovim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ This contains plugins and other goodies for various text editors.
 ## Vim ##
 
 * [SLIMV](https://github.com/kovisoft/slimv) - Superior Lisp Interaction Mode for Vim; a full-blown environment for Common Lisp inside of Vim. No license specified.
+* [Vlime](https://github.com/l04m33/vlime) - VLIME: Vim plus Lisp Is Mostly Evil. A Common Lisp dev environment for Vim (and Neovim). [MIT][200].
 
 Tools
 =====


### PR DESCRIPTION
Vlime is a Common Lisp dev environment, which is similar to SLIMV, but utilizes some new Vim 8 features.

Disclaimer: I wrote it :)