### PR TITLE
arrow-macros threading macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Language extensions
 * [cl-2dsyntax](http://www.cliki.net/cl-2dsyntax) - An indentation-sensitive reader system. Not available on Quicklisp. No license specified.
 * [cl-annot](https://github.com/m2ym/cl-annot) - Python-like annotations for Common Lisp. [LLGPL][8].
 * [cl-interpol](http://www.cliki.net/cl-interpol) - A set of reader modifications to allow string interpolation. No license specified.
+* [arrow-macros](https://github.com/hipeta/arrow-macros) - Clojure-like threading macros. [MIT][200].
 
 
 


### PR DESCRIPTION
with very nice ones, like some->> which returns nil if a form in the middle evaluates to nil (so like a *monad*).

There's cl-arrows, but less complete.