### PR TITLE
find-port: find open ports programmatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Others
 * [css-lite](https://github.com/paddymul/css-lite) - A CSS grammar. [Expat][14].
 * [Postmaster](https://github.com/eudoxia0/postmaster) - A simple, easy-to-use SMTP/IMAP library. [Expat][14].
 * [usocket](https://github.com/usocket/usocket) - A portable TCP and UDP socket interface. [Expat][14].
+* [find-port](https://github.com/eudoxia0/find-port) -  Programmatically find open ports. [MIT][200].
 
 
 Numerical and Scientific


### PR DESCRIPTION
The goal of this is rather simple than awesome, but it is handy. Most tutorials and readmes of webservers out there hardcode the port to run the app… I hit this inconvenience many times and I was happy to discover this lib some day, by reading sources.