### PR TITLE
add Snooze REST framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Web frameworks
 * [ningle](https://github.com/fukamachi/ningle) - A super-micro web framework. [LLGPL][8].
 * [radiance](https://github.com/Shirakumo/radiance) - An extensible framework library and multi-application CMS. [Artistic License 2.0][51].
 * [Lucerne](https://github.com/eudoxia0/lucerne) - A minimal web framework built on Clack, inspired by Flask. [MIT][200].
+* [Snooze](https://github.com/joaotavora/snooze) - A RESTful web framework, built on Clack, where routes are just functions and HTTP conditions are just Lisp conditions. [LLGPL][8].
 
 There are more projects, more or less discontinued but interesting. See the other ressources.
 


### PR DESCRIPTION
It looks very neat to me. I tried quickly.
https://github.com/joaotavora/snooze (author of Sly, Yasnippet,…).
With it routes are regular lisp methods, route parameters are regular function parameters. It is a big difference with others (Caveman and Ningle, Lucerne allright) where accessing (url query) parameters is verbose and inconsistent.