### PR TITLE
add staple, documentation builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,10 @@ Documentation builders
   the same ease as sphinx would a Python project. [GPL3][2]
 * [Codex](https://github.com/CommonDoc/codex) - A beautiful
   documentation system for Common Lisp. [MIT][200].
+* [Staple](https://github.com/Shinmera/staple) - a tool to generate
+  documentation pages using an HTML template. Uses the existing
+  README, adds docstrings, crossreferences and links to the
+  CLHS. [ArtisticLicense2.0][51].
 
 Markdown
 --------

--- a/README.md
+++ b/README.md
@@ -625,7 +625,6 @@ Language extensions
 * [trivial-types](https://github.com/m2ym/trivial-types) - Trivial type definitions. [LLGPL][8].
 * [interface](https://bitbucket.org/tarballs_are_good/interface) - A protocol library. [3-clause BSD][15].
 * [cl-syntax](https://github.com/m2ym/cl-syntax) - Reader syntax conventions. [LLGPL][8].
-* [closer-mop](http://cliki.net/closer-mop) - A compatibility layer that rectifies many absent or incorrect MOP features. [Expat][14].
 * [cl-2dsyntax](http://www.cliki.net/cl-2dsyntax) - An indentation-sensitive reader system. Not available on Quicklisp. No license specified.
 * [cl-annot](https://github.com/m2ym/cl-annot) - Python-like annotations for Common Lisp. [LLGPL][8].
 * [cl-interpol](http://www.cliki.net/cl-interpol) - A set of reader modifications to allow string interpolation. No license specified.
@@ -638,6 +637,10 @@ Language extensions
   the current stack is still useful to store
   somewhere. [Artistic License 2.0][51].
 
+### CLOS extensions
+
+* [Cells](https://github.com/kennytilton/cells) - "an implementation of the dataflow programming paradigm", or "reactive spreadsheet-like expressiveness for CLOS". Used to build an [algebra learning system](http://tiltontec.com/). With [documentation](https://github.com/stefano/cells-doc/). Lisp LGPL.
+* [closer-mop](http://cliki.net/closer-mop) - A compatibility layer that rectifies many absent or incorrect MOP features. [Expat][14].
 
 
 Files and directories


### PR DESCRIPTION
It's very nice since it uses the readme and creates *one* final html file, easy to publish anywhere. Used by Shinmera everywhere.