### PR TITLE
Add modern public domain online CLOS MOP specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Reference
 
 * [Common Lisp Quick Reference](http://clqr.boundp.org/index.html) - A distilled, pocket-size version of the ANSI CL spec. Available for download as a PDF.
 * [CLHS](http://www.lispworks.com/documentation/lw50/CLHS/Front/index.htm) - The Common Lisp HyperSpec; the ANSI CL standard, in hypertext form.
+* [CLOS MOP specification](https://clos-mop.hexstreamsoft.com/) - A modern public domain online version of chapters 5 and 6 of The Art of the Metaobject Protocol
 * [Common Lisp Standard Draft](http://cvberry.com/tech_writings/notes/common_lisp_standard_draft.html) - The final draft of the Common Lisp specifications, in a well formatted PDF.
 * [Common Lisp the Langauge](http://www.cs.cmu.edu/Groups/AI/html/cltl/cltl2.html) - The original standard for Common Lisp before the ANSI spec.
 * [Minispec](http://minispec.org/index.html) - A friendlier, but less-complete, version of CLHS. Also contains documentation for some commonly-used CL libraries (such as Alexandria).


### PR DESCRIPTION
Hello,

My modern public domain online version of the CLOS MOP specification was first released on 15 october 2017, and after further improvements, although my full vision has not yet been realized I feel this is in quite good enough shape to submit to awesome-cl.

Full faithfulness to the contents of the book has been a top priority, which was ensured by carefully auditing the new version against the actual book, so this is very complete and safe to use. Mobile support is already implemented, and offline support and further improvements are underway.

I think it's safe to say that most people would prefer to use this new version over any other previously existing versions. A cursory look at my version should easily convince most people of this.

https://clos-mop.hexstreamsoft.com/

I hope this is to your satisfaction.

-------------------------------------------

(I inserted my entry right after the CLHS entry (and before other CLHS stuff) because the CLOS MOP is probably the most important Common Lisp de-facto standard, and it is widely supported in all modern Common Lisp implementations, and users can easily make use of it through the `closer-mop` de-facto standard compatibility library (which was a Top 3 Common Lisp library for all of 2017 according to Quicklisp download stats). So I consider this more pragmatically important than the later entries in the `Reference` section.)

(Note that all or almost all of the CSS validation "errors" (as seen when clicking on "✔ CSS3" at the bottom of the page) stem from the validator not yet supporting CSS variables, a widely supported feature in all modern standards-compliant browsers. I consider this a bug in the validator.)
  