### PR TITLE
add cl-selenium-webdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,10 +564,11 @@ Others
 * [cl-closure-template](https://github.com/archimag/cl-closure-template) - Implementation of Google's Closure templates. [LLGPL][8].
 * [colleen](https://github.com/Shinmera/colleen) - IRC bot with a modular framework. [Artistic License 2.0][51].
 * [css-lite](https://github.com/paddymul/css-lite) - A CSS grammar. [Expat][14].
-* [Postmaster](https://github.com/eudoxia0/postmaster) - A simple, easy-to-use SMTP/IMAP library. [Expat][14].
-* [usocket](https://github.com/usocket/usocket) - A portable TCP and UDP socket interface. [Expat][14].
 * [find-port](https://github.com/eudoxia0/find-port) -  Programmatically find open ports. [MIT][200].
 * [Cl-forms](https://github.com/mmontone/cl-forms) -  Web forms handling library for Common lisp. [MIT][200].
+* [Postmaster](https://github.com/eudoxia0/postmaster) - A simple, easy-to-use SMTP/IMAP library. [Expat][14].
+* [cl-selenium-webdriver](https://github.com/TatriX/cl-selenium-webdriver/) - a binding library to Selenium 2.0.
+* [usocket](https://github.com/usocket/usocket) - A portable TCP and UDP socket interface. [Expat][14].
 
 Numerical and Scientific
 ========================


### PR DESCRIPTION
https://github.com/quicklisp/quicklisp-projects/issues/1456

> Looks like cl-selenium is not maintained and basically unusable. It uses very old selenium api.