### PR TITLE
add arrow-macros, clojure-like threading macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Language extensions
 * [cl-2dsyntax](http://www.cliki.net/cl-2dsyntax) - An indentation-sensitive reader system. Not available on Quicklisp. No license specified.
 * [cl-annot](https://github.com/m2ym/cl-annot) - Python-like annotations for Common Lisp. [LLGPL][8].
 * [cl-interpol](http://www.cliki.net/cl-interpol) - A set of reader modifications to allow string interpolation. No license specified.
+* [arrow-macros](https://github.com/hipeta/arrow-macros) - Clojure-like threading macros. [MIT][200].
 * [dissect](https://shinmera.github.io/dissect) - when a lot of
   projects use the “trivial-backtrace” system that just gives them a
   string with a backtrace, Dissect allows you to capture, step, and


### PR DESCRIPTION
closes https://github.com/CodyReichert/awesome-cl/pull/80/

cl-arrows is abandonned
it was forked but the fork was quickly abandonned in favour of
arrow-macros
https://github.com/eschulte/cl-arrowz/commit/dc306e727c3c60963cf36fdcf87ea8fb9a47e29a