### PR TITLE
add Clamp - Arc's terseness for CL

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ sellers who aren't evil for physical resources.
     - [Logging](#logging)
     - [Markdown](#markdown)
     - [Plotting](#plotting)
-    - [Text Processing](#text-processing)
     - [Other](#other)
 - [XML](#xml)
 - [Contributing](#contributing)


### PR DESCRIPTION
> Arc is an amazing programming language because of its brevity and succinctness, but at the same time, it lacks some of the most basic features of a programming language. It has neither a debugger nor a module system. Common Lisp on the other hand has many of the fundamentals that Arc lacks and much more (restarts, reader macros, etc), but lacks the conciseness of Arc. Clamp is an attempt to bring the powerful, but verbose, language of Common Lisp up to the terseness of Arc.

https://www.reddit.com/r/lisp/comments/8z34az/anarki_communitymanaged_fork_of_the_arc_dialect/