### PR TITLE
Update link for cl-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,7 @@ Git
 i18n
 ----
 
-* [cl-i18n](https://bitbucket.org/skypher/cl-i18n/) - an i18n library. Load translations from GNU gettext text or binary files or from its native format. Localisation helpers of plural forms. [LLGPL][8].
+* [cl-i18n](https://notabug.org/cage/cl-i18n) - an i18n library. Load translations from GNU gettext text or binary files or from its native format. Localisation helpers of plural forms. [LLGPL][8].
 * [cl-locale](https://github.com/fukamachi/cl-locale) - A simple i18n library. [LLGPL][8].
 * [enchant](https://github.com/tlikonen/cl-enchant) - bindings for the Enchant spell-checker library. Public domain.
 * [oxenfurt](https://github.com/Shinmera/oxenfurt) - A  client library for the Oxford dictionary API. [ArtisticLicense2.0][51].


### PR DESCRIPTION
Fixes #192

cc @vindarel -- looks like this is the repo quicklisp and everything
else is pulling from too. Look good to you?