### PR TITLE
Fix `screamer-plus` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,9 @@ Non-deterministic, logic programming
 * [Screamer](https://github.com/nikodemus/screamer) - augment Common
   Lisp with practically all of the functionality of both Prolog and
   constraint logic programming
-  languages. [MIT][200]. [Screamer+](https://github.com/ysz/screamer-plus) -
-  increasing the expressiveness of
-  SCREAMER. [Blog post](https://chriskohlhepp.wordpress.com/reasoning-systems/specification-driven-programming-in-common-lisp/)
-  solving Project Euler puzzles.
+  languages. [Blog post](https://chriskohlhepp.wordpress.com/reasoning-systems/specification-driven-programming-in-common-lisp/)
+  solving Project Euler puzzles. [MIT][200].
+* [Screamer+](https://github.com/yakovzaytsev/screamer-plus) - increasing the expressiveness of SCREAMER.
 * [Temperance](https://sjl.bitbucket.io/temperance/) - logic programming. [MIT][200]. A focus on performance, with General Game Playing in mind.
 
 Reactive programming


### PR DESCRIPTION
Fixes #204 

See: https://github.com/CodyReichert/awesome-cl/issues/204#issuecomment-432653420

---

@vindarel, question for you: I moved `screamer-plus` to it's own line, do you think that makes sense here? I figured it was a small section, so it makes it a little easier to read.