### PR TITLE
Keep notabug repo in sync with GitHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ gh-pages:
 	git commit -m "Rebuild index.md"
 	git push -u origin gh-pages
 	git checkout master
+	
+	# Push new changes to the notabug repo so they stay in sync
+	git remote add notabug git@notabug.org:CodyReichert/awesome-cl.git
+	git push notabug master


### PR DESCRIPTION
Fixes #193 (hopefully :D)

Notabug doesn't have a 'mirror' option, like GitHub does. But we're already running these commands in the Makefile when we merge to master, so we can push all new changes to notabug here also.

(FWIW - the Makefile for gh-pages is actually unnecessary, we should be able to read directly from `master`, but...if it ain't broke don't fix it! :wrench:)