### PR TITLE
Update .travis.yml for notabug repo synchronizing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@
 # pushing the new README.
 
 script:
+  # Sync changes with https://notabug.org/CodyReichert/awesome-cl
+  - git remote add notabug https://notabug.org/CodyReichert/awesome-cl.git
+  - git push notabug master
   # Publish changes to https://awesome-cl.com
   - git clone --branch=gh-pages https://github.com/CodyReichert/awesome-cl dist
   - cp README.md dist/index.md


### PR DESCRIPTION
The notabug repo is outdated for about a month. With this change we can make them consistent.