### PR TITLE
add cl-gearman, distributed job system

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,7 @@ Parallelism and Concurrency
 * [trivial-monitored-thread](https://gitlab.com/ediethelm/trivial-monitored-thread) -
   a Common Lisp library offering a way of spawning threads and being
   informed when one any of them crash and die. [MIT][200].
+* [cl-gearman](https://github.com/taksatou/cl-gearman) - a library for the [Gearman](http://gearman.org/) distributed job system. [LLGPL][8].
 
 
 Event processing


### PR DESCRIPTION
Seems relevant because it is used by Ultralisp in lieu of lfarm.