### PR TITLE
Fix/remove broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Beginner
 --------
 
 * [Learn X in Y minutes - Where X = Common Lisp](https://learnxinyminutes.com/docs/common-lisp/) - Small Common Lisp tutorial covering the essentials.
-* [Practical Common Lisp][206] - A good introductory text to Common Lisp, with practical examples. (better read with [a Firefox add-on](https://addons.mozilla.org/de/firefox/addon/beautify-practical-common-lisp/?src=search))
+* [Practical Common Lisp][206] - A good introductory text to Common Lisp, with practical examples.
 * [Common LISP: A Gentle Introduction to Symbolic Computation](http://www.cs.cmu.edu/afs/cs.cmu.edu/user/dst/www/LispBook/index.html) - A nice introduction into the language.
 * [Learn LISP: Simply Easy Learning](http://www.tutorialspoint.com/lisp/index.htm) - A good set of introductory tutorials; includes interactive examples.
 * [Successful Lisp](http://successful-lisp.blogspot.com/) - A good book for beginners with some programming background.
@@ -581,7 +581,7 @@ Natural Language Processing
 ===========================
 
 * [cl-nlp](https://github.com/vseloved/cl-nlp) - Natural language processing toolset. [Apache2.0][89].
-* [babel2](http://emergent-languages.org/Babel2/) - A Fluid Construction Grammar implementation, computational framework, and unification-based grammar formalism [Apache2.0][89].
+* [babel2](https://github.com/lucas8/Babel2/) - A Fluid Construction Grammar implementation, computational framework, and unification-based grammar formalism [Apache2.0][89].
 * [sparser](https://github.com/ddmcdonald/sparser) - A natural
 language understanding system for English. [Eclipse][209].
 
@@ -873,8 +873,7 @@ executable for a Lisp version of the canonical `Hello World!`
 program requires only 20k bytes on 32 bit x86 Linux.  WCL also
 supports a full development environment, including dynamic file
 loading and debugging.  A modified version of GDB is used to debug WCL
-programs, providing support for mixed language debugging. With
-[a paper](http://pgc.com/commonlisp/wcl-paper.html).
+programs, providing support for mixed language debugging.
 * [replic](https://github.com/vindarel/replic/) - helpers to turn existing code into a readline application, with a focus on defining the completion of the commands' arguments. Also comes as a ready to use executable, that transforms a user's lispy init file into readline commands. [MIT][200].
 * [cl-all](https://github.com/shinmera/cl-all) - A script to run Lisp snippets in multiple implementations. This allows you to quickly compare implementation behaviour and differences. [Artistic License 2.0][51].
 


### PR DESCRIPTION
Fixes #263 

Unfortunately it looks like some of these URLs aren't available anymore. I tried to give it some time in case it was just a hosting issue or something similar, but after a few weeks all of these sites are still unavailable. Here's what's changed:

#### Practical Common Lisp Firefox Addon
This doesn't seem to be available in the Firefox Addons directory anymore. There _is_ [a GitHub repo with the code](https://github.com/vale981/practical-cl-beautified), but the repo does not contain any installation or usage instructions, so I think it's not very useful to the people who would need it.

This removed it, should we instead link to the GitHub repo?

#### Babel2
It looks like they redid their site and they no longer have the `/Babel2` page. IMO the GitHub repo is probably a little more useful for our situation, since the site just has a contact form.

This updates the link to use GitHub. Would it make more sense to use [the new site](https://emergent-languages.org/)?

#### WCL (paper only)
WCL is still valid, but there was a link to the whitepaper in the description that is no longer available. I looked around to see if it was hosted somewhere else, but wasn't able to find anything. They do have the _source_ for the paper [on GitHub](https://github.com/wadehennessey/wcl/tree/master/doc), but again I think this is less useful for our situation.

This just removes the link to the paper, WCL is still listed.

---

@vindarel - Think that was a good call on each of those? I mentioned some possible alternatives, and I would be good to do any of those!