### PR TITLE
add sanity-clause. Allows to check slots types at make-instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ Data validation
 
 * [ratify](https://github.com/Shinmera/ratify) - A collection of utilities to ratify, validate and parse inputs. [Artistic License 2.0][51].
 * [clavier](https://github.com/mmontone/clavier) - General purpose validation library for Common Lisp. [MIT][200].
+* [sanity-clause](https://github.com/fisxoj/sanity-clause) - a data serialization/contract library for Common Lisp. Schemas can be property lists or class-based, allowing to check slots' types during `make-instance`. [LLGPL][8].
 
 Developer utilities
 -------------------


### PR DESCRIPTION
see also https://stackoverflow.com/questions/51723992/how-to-force-slots-type-to-be-checked-during-make-instance/56920918

(note that I recently inadvertently pushed easy-routes without a PR: https://github.com/mmontone/easy-routes)