### PR TITLE
Added CMN (Common Music Notation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Audio
 ancient version of Common Music (version 2.12.0), the presumably last
 version which ran on Common Lisp dating from around 2007-09, before
 work on Common Music shifted to (scheme-based) cm3.
+* [Common Music Notation](https://ccrma.stanford.edu/software/cmn/) - Common Music Notation (CMN) provides a package of functions to hierarchically describe a musical score. Public domain. 
 * [cm-incudine](https://github.com/ormf/cm-incudine) - extends Common Music 2 with realtime capabilities. GPL2.
 * [Mégra](https://github.com/the-drunk-coder/megra) - A mini-language to make music with variable-order markov chains and some other stochastic shenanigans. [GPL3][2].
 * [Music](https://github.com/MegaLoler/Music) - A framework for musical expression in Lisp with a focus on music theory (built from scratch, unrelated to Common Music).


### PR DESCRIPTION
This program uses CLOS. It renders a postscript file of a musical score that can then be converted to a pdf.
It is also one of [slippery chicken's](http://michael-edwards.org/sc/) music notation backends in addition to lilypond and musicxml.
A wikipedia entry for the program can be found [here](https://en.wikipedia.org/wiki/Common_Music_Notation).
The program's manual and documentation can be found [here](https://ccrma.stanford.edu/software/cmn/cmn/cmn.html)