### PR TITLE
add FUNDING.yml (GitHub "sponsors" button).

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+
+# github: [vindarel,] # ongoing
+ko_fi: vindarel
+liberapay: vindarel
+patreon: vindarel


### PR DESCRIPTION
Hi all,

I was wondering if I could add myself in the "sponsors" GitHub button. Does that sound strange to someone? After all, I still commit here regularly (455 commits in total according to `git rev-list --count HEAD  --author "vindarel"`), and this repository is the one with the most stars I (still) contribute to :]

I currently don't have a fixed (nor big) income, so some tips would help.

Last thing, we can add more than one nickname on some fields of the FUNDING file, such as the "github" field, and we can add custom links.

https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository

Best,
Vincent