### PR TITLE
Remove daewok Docker images and replace with cl-docker-images project

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,11 +340,10 @@ Other data structures:
 Docker images
 =============
 
-* [docker-sbcl](https://github.com/daewok/docker-sbcl/) - SBCL Docker images for Alpine, Debian, Ubuntu (amd64, arm64, arm/v7) and Windows. [BSD_2Clause][17].
+* [cl-docker-images](https://common-lisp.net/project/cl-docker-images) - Docker images for ABCL, CCL, ECL, and SBCL on Windows (amd64) and Alpine and Debian (amd64, arm64, arm/v7) [BSD_2Clause][17].
 * [base-lisp-image](https://github.com/40ants/base-lisp-image) - base
   Docker image for Common Lisp projects with SBCL or CCL and the latest
   ASDF, Qlot and Roswell.
-* [lisp-devel-docker](https://github.com/daewok/lisp-devel-docker) - Docker images for Lisp development. [MIT][200].
 
 
 Foreign Function Interface, languages interop


### PR DESCRIPTION
daewok has moved his images into a dedicated project. Images are hosted on CL
Foundation owned namespace on Docker Hub.