### PR TITLE
adds cl-smtp to the list, an smtp client

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ Email
 * [trivial-imap](https://github.com/40ants/trivial-imap) - tries to make easy some common cases of working with IMAP servers, like reading emails from the server. A thin wrapper over post-office library (which is a fork of Franz's cl-imap). [BSD][15].
 * [mailgun](https://github.com/40ants/mailgun) - A thin wrapper to post HTML emails through mailgun.com. [unlicence][5].
 * [mito-email-auth](https://github.com/40ants/mito-email-auth) - Helper to authenticate a website's users by sending them unique code by email.
+* [cl-smtp](https://gitlab.common-lisp.net/cl-smtp/cl-smtp) - CL-SMTP is a simple lisp smtp client. 
 
 
 Websockets


### PR DESCRIPTION
This PR adds [cl-smtp](https://gitlab.common-lisp.net/cl-smtp/cl-smtp) under the e-mail section. It appears to be a mature and simple [smtp]() library which I plan on using for a small future project.