### PR TITLE
Remove Lucerne, place Snooze under proper subheading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,12 +838,12 @@ Web frameworks
   Example projects: [Quickdocs](https://github.com/quickdocs)
 * [hh-web](https://github.com/hargettp/hh-web) - Framework for building modern web apps. [Expat][14].
 * [ningle](https://github.com/fukamachi/ningle) - A super-micro web framework. [LLGPL][8]. [ninglex](https://github.com/defunkydrummer/ninglex), an extended and noob-friendly ningle (mostly easier handling of query parameters). [MIT][200].
-* [radiance](https://github.com/Shirakumo/radiance) - A web application environment and framework . [zlib][33].
 * [Lucerne](https://github.com/eudoxia0/lucerne) - A minimal web framework built on Clack, inspired by Flask. [MIT][200].
-* [Snooze](https://github.com/joaotavora/snooze) - A RESTful web framework. Web server agnostic. Currently has support for Hunchentoot and Clack. Routes are just functions and HTTP conditions are just Lisp conditions. [LLGPL][8].
+* [radiance](https://github.com/Shirakumo/radiance) - A web application environment and framework . [zlib][33].
 
 REST-focused frameworks:
 
+* 👍 [Snooze](https://github.com/joaotavora/snooze) - A RESTful web framework. Web server agnostic. Currently has support for Hunchentoot and Clack. Routes are just functions and HTTP conditions are just Lisp conditions. [LLGPL][8].
 * [cl-rest-server](https://github.com/mmontone/cl-rest-server) - a library for writing REST web APIs. Features validation with schemas, annotations for logging, caching, permissions or authentication, documentation via Swagger, etc. [MIT][200].
 * [cl-odata-client](https://github.com/copyleft/cl-odata-client) - Common Lisp client library for accessing [OData services](https://www.odata.org). [MIT][200].
 
@@ -853,7 +853,7 @@ Authentication plugins (in addition to the Clack plugins above):
 * [cas-middleware](https://github.com/fferrere/cas-middleware) - CAS authenticaton middleware for Caveman.
   * [cas-demo](https://github.com/fferrere/cas-demo) - a demo project.
 
-There are more projects, more or less discontinued but interesting. See the other ressources.
+There are more projects, more or less discontinued but interesting. See the other resources.
 
 Isomorphic web frameworks
 -------------------------


### PR DESCRIPTION
As per https://github.com/eudoxia0/lucerne/issues/30 , Lucerne has not been
available on quicklisp for close to a year. Perhaps better placed in Cliki than
this curated list? Hopefully a Lucerne user can reinstate Lucerne back to
quicklisp.

I propose to add a thumbs up to snooze.

- Arguably the tightest integration to CL concepts or the most "lispy" way to do
  things. https://github.com/joaotavora/snooze#rationale
- Mature (7 years), and with recent commits.
- Most widespread out of all web frameworks currently listed, insofar as
  quicklisp download stats are concerned. N.B. Caveman depends on ningle.

``` common-lisp

CL-USER> (ql:quickload :quicklisp-stats)
To load "quicklisp-stats":
  Load 1 ASDF system:
    quicklisp-stats
; Loading "quicklisp-stats"
.....
(:QUICKLISP-STATS)
CL-USER> (loop for lib in '("caveman" "hh-web" "ningle" "snooze")
      do (progn
           (format t ";;; ===== ~a =====~%" lib)
           (loop for ((year month) . data) in (quicklisp-stats:all)
                 for result = (alexandria:assoc-value data lib
                                                      :test #'equal)
                 do (format t ";; ~4,'0D-~2,'0D: ~D~%" year month result))))
;;; ===== caveman =====
;; 2020-01: 267
;; 2020-02: 407
;; 2020-03: 265
;; 2020-04: 299
;; 2020-05: 274
;; 2020-06: 261
;; 2020-07: 248
;; 2020-08: 172
;; 2020-09: 118
;; 2020-10: 124
;; 2020-11: 100
;; 2020-12: 79
;; 2021-01: 285
;; 2021-02: 111
;; 2021-03: 84
;; 2021-04: 117
;; 2021-05: 88
;; 2021-06: 142
;; 2021-07: 430
;; 2021-08: 468
;; 2021-09: 346
;; 2021-10: 304
;; 2021-11: 302
;; 2021-12: 269
;; 2022-01: 188
;; 2022-02: 376
;; 2022-03: 1
;;; ===== hh-web =====
;; 2020-01: 69
;; 2020-02: 172
;; 2020-03: 28
;; 2020-04: 26
;; 2020-05: NIL
;; 2020-06: NIL
;; 2020-07: NIL
;; 2020-08: 116
;; 2020-09: NIL
;; 2020-10: NIL
;; 2020-11: NIL
;; 2020-12: NIL
;; 2021-01: 198
;; 2021-02: NIL
;; 2021-03: NIL
;; 2021-04: NIL
;; 2021-05: NIL
;; 2021-06: NIL
;; 2021-07: NIL
;; 2021-08: NIL
;; 2021-09: NIL
;; 2021-10: NIL
;; 2021-11: NIL
;; 2021-12: NIL
;; 2022-01: NIL
;; 2022-02: NIL
;; 2022-03: NIL
;;; ===== ningle =====
;; 2020-01: 509
;; 2020-02: 694
;; 2020-03: 370
;; 2020-04: 598
;; 2020-05: 478
;; 2020-06: 647
;; 2020-07: 502
;; 2020-08: 315
;; 2020-09: 288
;; 2020-10: 243
;; 2020-11: 364
;; 2020-12: 199
;; 2021-01: 491
;; 2021-02: 131
;; 2021-03: 259
;; 2021-04: 470
;; 2021-05: 314
;; 2021-06: 203
;; 2021-07: 504
;; 2021-08: 764
;; 2021-09: 457
;; 2021-10: 603
;; 2021-11: 502
;; 2021-12: 580
;; 2022-01: 452
;; 2022-02: 551
;; 2022-03: 1
;;; ===== snooze =====
;; 2020-01: 633
;; 2020-02: 725
;; 2020-03: 847
;; 2020-04: 1030
;; 2020-05: 1150
;; 2020-06: 1262
;; 2020-07: 1664
;; 2020-08: 984
;; 2020-09: 802
;; 2020-10: 1070
;; 2020-11: 1273
;; 2020-12: 769
;; 2021-01: 950
;; 2021-02: 1178
;; 2021-03: 1013
;; 2021-04: 718
;; 2021-05: 842
;; 2021-06: 1268
;; 2021-07: 955
;; 2021-08: 739
;; 2021-09: 1137
;; 2021-10: 1138
;; 2021-11: 506
;; 2021-12: 604
;; 2022-01: 961
;; 2022-02: 1153
;; 2022-03: NIL
NIL
CL-USER>

```

Cl-rest-server shared a similar state to Lucerne, but I see that it is in a WIP
state as of 14 days to this date. Cl-odata-client, cl-cas, cas-middleware and
cas-demo are all unavailable on quicklisp -- Radiance being a separate case --
and glancing over the repositories, seems to show no (or very little) usage.

I'm of the opinion that they deserve mention on Cliki or one's own personal
notes, but including such entries shifts awesome-cl into more of a
[collection than a curation](https://github.com/sindresorhus/awesome/blob/main/awesome.md#the-awesome-manifesto).

I believe we could take advantage of the fact that libraries on Cliki already
have a taxonomy and linking each respective section on awesome-cl and cliki
together in order to give a very seamless transition from curation >
collection. As always, happy to hear your thoughts.

Best,