### PR TITLE
add: bp (bitcoin protocol components)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Cryptography
 Cryptocurrencies
 ================
 
+* [bp](https://github.com/rodentrabies/bp) - Bitcoin Protocol components in Common Lisp. [MIT][200].
 * [cl-monero-tools](https://github.com/glv2/cl-monero-tools) -  Common Lisp toolbox to work with the Monero cryptocurrency. [GPL3][2]. Not in Quicklisp.
 * [emotiq](https://github.com/emotiq/emotiq) - a next-generation blockchain with an innovative natural-language approach to smart contracts. [MIT][200].
 * [peercoin-blockchain-parser](https://github.com/glv2/peercoin-blockchain-parser) - parse the blockchain contained in a file and export some of its data to a text file, a SQL script or a database. It can also create a database using the RPC of a Peercoin daemon as source of data instead of a blockchain file. LGPL3. Not in Quicklisp.


### PR DESCRIPTION
Contrary to the contribution guidelines, `bp` is added to the beginning of the section. This is because bitcoin is the most important digital currency. If you still want it at the end, just let me now and I'll fix it.