### PR TITLE
Add cl-semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,7 @@ Data validation
 * [clavier](https://github.com/mmontone/clavier) - General purpose validation library for Common Lisp. [MIT][200].
 * [json-schema](https://github.com/fisxoj/json-schema) - A library for validating data against schemas of drafts 4, 6, 7, and 2019-09 of the [JSON Schema](https://json-schema.org/) standard. [LLGPL][8].
 * [sanity-clause](https://github.com/fisxoj/sanity-clause) - a data serialization/contract library for Common Lisp. Schemas can be property lists or class-based, allowing to check slots' types during `make-instance`. [LLGPL][8].
+* [cl-semver](https://github.com/cldm/cl-semver) - Implementation of the [Semantic Versioning](https://semver.org) Specification. [MIT][200]
 
 Developer utilities
 -------------------


### PR DESCRIPTION
[Cl-semver](https://github.com/cldm/cl-semver) implements the [Semantic Version](https://semver.org/) Specification.

It is added in the [Data validation section](https://github.com/CodyReichert/awesome-cl#data-validation). If you want it somewhere else, just tell it :)