### PR TITLE
Add cl-telegram-bot-auto-api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,7 @@ Service (S3) and CloudFront service. [BSD][15].
 * [lisp-pay](https://github.com/K1D77A/lisp-pay) - Wrappers around various payment processors: Paypal, Stripe, Coinpayments and BTCPayServer. [MIT][200].
 * [lunamech-matrix-api](https://github.com/K1D77A/lunamech-matrix-api) - A complete wrapper over the Client -> Server Matrix API. [MIT][200].
 * [cl-telegram-bot](https://40ants.com/cl-telegram-bot/) - Telegram bot API. [MIT][200].
+  * [cl-telegram-bot-auto-api](https://github.com/aartaka/cl-telegram-bot-auto-api) - Alternative Telegram Bot API bindings, auto-generated from Telegram website. [3-clause BSD][15].
 
 
 Numerical and Scientific


### PR DESCRIPTION
This add another Telegram Bot API library. Mentioned as a sub-point of the main inspiration—`cl-telegram-bot-api`.