### PR TITLE
Developer utilities: Graven Image `benchmark*` macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1695,6 +1695,7 @@ and also:
 
 * [GTFL](http://www.martin-loetzsch.de/gtfl/) - A graphical terminal for Lisp, meant for Lisp programmers who want to debug or visualize their own algorithms. A graphical trace in the browser. BSD-style.
 * [trivial-benchmark](https://github.com/Shinmera/trivial-benchmark) - Tiny benchmarking library. [zlib][33].
+  * [Graven Image's `benchmark*` macro](https://github.com/aartaka/graven-image#benchmark-macro) - A macro modeled after `trivial-benchmark`, but with additional support for CCL, ECL, ABCL, CLISP, and Allegro. [BSD][15].
 * [glyphs](https://github.com/ahungry/glyphs/) - A library for cutting down the verboseness of Common Lisp in places. [GNU GPL3][2].
 * [Lisp REPL core dumper](https://gitlab.com/ambrevar/lisp-repl-core-dumper/) -
 A portable wrapper to generate Lisp cores on demand to start REPL blazing fast.


### PR DESCRIPTION
This mentions `graven-image:benchmark*` macro as a more portable alternative to `trivial-benchmark`. However, adding this line feels... questionable for a variety of reasons:
- This might be perceived as antagonistic to `trivial-benchmark` or squatting the space in the `awesome-cl` at someone else's cost. I don't want to convey such an image:
  - I've asked about my (`time`-gutting) approach [in `trivial-benchmark`](https://github.com/Shinmera/trivial-benchmark/issues/13) two weeks ago with no reply left as of PR creation moment.
  - There's a clear mention of what differentiates `benchmark*` from `trivial-benchmark`.
  - I'm also CC-ing @Shinmera for transparency purposes.
- Mentioning a single macro instead of the whole library seems quite atypical to `awesome-cl`. Should it be a library mention instead?
  - While I consider `benchmark*` macro production-ready, I don't perceive Graven Image as a library ready enough to be mentioned.
    - I'll be glad to accept an advice on what to do in such a situation.
    - I'm okay with either of
      - Not including this line here.
      - Rewriting it to mention Graven Image as a library in the Developer utilities section.
      - Or leaving it be as a macro mention.

Anyway, huge thanks for maintaining this list :heart: 