### PR TITLE
Link closer-mop to official github repo instead of third-party wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ For strings:
 CLOS extensions
 ---------------
 
-* ⭐ [closer-mop](http://cliki.net/closer-mop) - A compatibility layer that rectifies many absent or incorrect MOP features. [Expat][14].
+* ⭐ [closer-mop](https://github.com/pcostanza/closer-mop) - A compatibility layer that rectifies many absent or incorrect MOP features. [Expat][14].
 * [specialization-store](https://github.com/markcox80/specialization-store/) - generic functions based on types. Simplified BSD License variant.
 * [filtered-functions](https://github.com/pcostanza/filtered-functions) - enable the use of arbitrary predicates for selecting and applying methods. [MIT][200].
 * [inlined-generic-function](https://github.com/guicho271828/inlined-generic-function) -


### PR DESCRIPTION
Previously this link went to a cliki article. You can get to the official page for closer-mop from this point, but it takes several blind clicks. Now it points directly to the official Github repository.