### PR TITLE
Add cl-cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,7 @@ Others
 * [find-port](https://github.com/eudoxia0/find-port) -  Programmatically find open ports. [MIT][200].
 * [cl-wget](https://github.com/cl-wget/cl-wget) - Makes retrieving large files or mirroring entire websites easy. [AGPL-3.0][51].
 * [trivial-download](https://github.com/eudoxia0/trivial-download) - Download files. [MIT][200].
+* [cl-cookie](https://github.com/fukamachi/cl-cookie) HTTP Cookie (jar) manager: parse and write (set-)cookie headers, compare cookies, optional cookie attribute sanity check. [MIT][200]
 
 
 ### Email


### PR DESCRIPTION
HTTP Cookie (jar) manager:
- parse and write (set-)cookie headers
- compare cookies
- optional cookie attribute sanity check.

Link: https://github.com/fukamachi/cl-cookie
MIT license