### PR TITLE
refactor: update stripe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1352,7 +1352,7 @@ Service (S3) and CloudFront service. [BSD][15].
 * [cl-pushover](https://github.com/TeMPOraL/cl-pushover) -  Common Lisp bindings to Pushover. [MIT][200].
 * [humbler](https://github.com/Shinmera/humbler) - A Tumblr API interface. [zlib][33].
 * [multiposter](https://github.com/Shinmera/multiposter) - post to multiple services simultaneously. [zlib][33].
-* [stripe](https://github.com/atlas-engineer/stripe) - a client for the Stripe payment system. [MIT][200].
+* [stripe](https://github.com/boogsbunny/stripe) - a client for the Stripe payment system. [MIT][200].
 * [lisp-pay](https://github.com/K1D77A/lisp-pay) - Wrappers around various payment processors: Paypal, Stripe, Coinpayments and BTCPayServer. [MIT][200].
 * [lunamech-matrix-api](https://github.com/K1D77A/lunamech-matrix-api) - A complete wrapper over the Client -> Server Matrix API. [MIT][200].
 * [cl-telegram-bot](https://40ants.com/cl-telegram-bot/) - Telegram bot API. [MIT][200].


### PR DESCRIPTION
## Background
<!-- Why are you making this change? What context does the reviewer need to know? -->
I've spoken to the [Atlas Engineer team](https://github.com/atlas-engineer) and we've decided that it's best if I resume the maintenance of the `stripe` package [here](https://github.com/boogsbunny/stripe) since they're so busy whereas I have more capacity.

One example is that I've recently added [webhook support](https://github.com/boogsbunny/stripe/commit/5936c43f44a197454095e1b83175dcdf3a303fd0).

## Changes
<!-- What changes did you make? Describe any tradeoffs you considered. -->
- Update stripe link