### PR TITLE
add cookiecutter-lisp-game; tweak docker-lisp-gamedev description

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,10 +469,7 @@ Docker images
   * for Ubuntu, OSX and Windows.
   * Example use: [Trial's CI](https://github.com/Shirakumo/trial/blob/master/.github/workflows/examples.yml)
 * [archlinux-cl](https://github.com/yitzchak/archlinux-cl) - Docker Arch Linux image with Common Lisp implementations (7 to this day). MIT.
-
-See also:
-
-* another [GitHub CI example from cookiecutter-lisp-game](https://github.com/lockie/cookiecutter-lisp-game/blob/main/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/package.yml) to build binaries on the three platforms.
+* [docker-lisp-gamedev](https://gitlab.com/lockie/docker-lisp-gamedev) - A Docker image containing tools necessary for Common Lisp game development and deployment. Comes in Linux and Windows variety. Thoroughly tested via CI.
 
 
 Foreign Function Interface, languages interop
@@ -2120,6 +2117,7 @@ Project skeletons
 * [cl-project-with-docs](https://github.com/40ants/cl-project-with-docs) - uses Sphinx and reStructured text to render nice and readable HTML documentation. [BSD][15].
 * [cl-cookieproject](https://github.com/vindarel/cl-cookieproject) -  Generate a ready-to-use Common Lisp project. Not in Quicklisp. [BSD_3Clause][15].
   * test definitions, entry point to run from sources, build a binary, Roswell integration…
+* [cookiecutter-lisp-game](https://github.com/lockie/cookiecutter-lisp-game) - An opinionated cookiecutter template for Common Lisp videogame projects. Allows to choose [backend middleware library](#graphics) between liballegro, raylib and SDL2. Contains CI scripts using [docker-lisp-gamedev](#docker-images) to automatically build binaries for Windows, MacOS and Linux.
 
 Security
 --------


### PR DESCRIPTION
Hello! This PR adds a separate entry for `cookiecutter-lisp-game` project and detailed description + URL for `docker-lisp-gamedev` (those are intertwined but separate projects).