### PR TITLE
Add cl-tron-mcp to the list of MCP projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Work In Progress:
 * [mcp-lisp](https://github.com/jsulmont/mcp-lisp) - Common Lisp SDK for MCP (2025-11-25) with full conformance (44/44 checks) and limited A2A support. Supports stdio and SSE transports, tools, resources, prompts, structured errors, and access logging. [MIT][200].
 * [Lisply MCP](https://github.com/gornskew/lisply-mcp) - a generic Node.js wrapper meant to work with pretty much any language backend which can support "eval" and http .
   * By default, it comes configured to work with an existing reference-implementation backend CL-based container image which it will pull and run on-demand.
-
+* [cl-tron-mcp](https://github.com/Alba-Intelligence/cl-tron-mcp) - MCP wrap around the Slime Swank library. Provides discoverable access to Swank commands, including control of the Swank debugging sessions and code hot-reload. Currentl 90+ tools. Tested on SBCL and ECL.
 
 ## Machine Learning
 


### PR DESCRIPTION
Add cl-tron-mcp to the list of MCP projects. This server wraps the commands provided by the Swank library. 