### PR TITLE
Add lisp-ts-mode to Emacs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2027,6 +2027,7 @@ This contains plugins and other goodies for various text editors.
 * ⭐ [Slime](https://github.com/slime/slime) - Superior Lisp Interaction Mode for Emacs; a full-blown environment for Common Lisp inside of Emacs. Public domain.
 * [Sly](https://github.com/joaotavora/sly) - SLY is a fork of SLIME and contains multiple changes and new features, such as Sly stickers.
   * *no C-c C-y shortcut aka slime-call-defun equivalent!*
+* [lisp-ts-mode](https://codeberg.org/zshaftel/lisp-ts-mode) - Tree-sitter powered Common Lisp major-mode with FORMAT string syntax highlighting and indentation. Compatible with Sly and Slime.
 
 Starter kits:
 


### PR DESCRIPTION
I added my recently released [lisp-ts-mode](https://codeberg.org/zshaftel/lisp-ts-mode) to the Emacs section.

Also, I'm working on [a semantic syntax highlighting package](https://codeberg.org/zshaftel/gaudy-cl) that utilizes both lisp-ts-mode and Sly/Slime. I haven't officially published it yet, but I've used it extensively and I consider it stable, so I'd like to let more people try it out. Could I add that to this PR as well?

Thanks!